### PR TITLE
B-02969 Make web-app JS code JSLint compatible

### DIFF
--- a/codestyles/idea/Enonic.xml
+++ b/codestyles/idea/Enonic.xml
@@ -1,312 +1,310 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="Enonic">
-    <option name="GENERATE_FINAL_LOCALS" value="true"/>
-    <option name="GENERATE_FINAL_PARAMETERS" value="true"/>
-    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99"/>
-    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99"/>
-    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value>
-            <package name="org.junit.Assert" withSubpackages="true" static="false"/>
-        </value>
-    </option>
-    <option name="IMPORT_LAYOUT_TABLE">
-        <value>
-            <package name="java" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="javax" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="org" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="com" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="com.enonic" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="com.enonic.cms.framework" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="com.enonic.cms" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="com.enonic.cms.business" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="com.enonic.cms.domain" withSubpackages="true" static="false"/>
-            <emptyLine/>
-            <package name="" withSubpackages="true" static="true"/>
-        </value>
-    </option>
-    <option name="RIGHT_MARGIN" value="140"/>
-    <option name="KEEP_LINE_BREAKS" value="false"/>
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-    <option name="BLANK_LINES_AROUND_FIELD" value="1"/>
-    <option name="BRACE_STYLE" value="2"/>
-    <option name="CLASS_BRACE_STYLE" value="2"/>
-    <option name="METHOD_BRACE_STYLE" value="2"/>
-    <option name="ELSE_ON_NEW_LINE" value="true"/>
-    <option name="WHILE_ON_NEW_LINE" value="true"/>
-    <option name="CATCH_ON_NEW_LINE" value="true"/>
-    <option name="FINALLY_ON_NEW_LINE" value="true"/>
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-    <option name="SPACE_WITHIN_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true"/>
-    <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true"/>
-    <option name="CALL_PARAMETERS_WRAP" value="1"/>
-    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-    <option name="EXTENDS_LIST_WRAP" value="1"/>
-    <option name="THROWS_LIST_WRAP" value="1"/>
-    <option name="EXTENDS_KEYWORD_WRAP" value="2"/>
-    <option name="THROWS_KEYWORD_WRAP" value="2"/>
-    <option name="BINARY_OPERATION_WRAP" value="1"/>
-    <option name="TERNARY_OPERATION_WRAP" value="5"/>
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-    <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-    <option name="ASSIGNMENT_WRAP" value="1"/>
-    <option name="IF_BRACE_FORCE" value="3"/>
-    <option name="DOWHILE_BRACE_FORCE" value="3"/>
-    <option name="WHILE_BRACE_FORCE" value="3"/>
-    <option name="FOR_BRACE_FORCE" value="3"/>
-    <option name="ENUM_CONSTANTS_WRAP" value="2"/>
-    <JSCodeStyleSettings>
-        <option name="SPACE_AFTER_PROPERTY_COLON" value="true"/>
-    </JSCodeStyleSettings>
-    <XML>
-        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
-    </XML>
-    <ADDITIONAL_INDENT_OPTIONS fileType="haml">
-        <option name="INDENT_SIZE" value="2"/>
-    </ADDITIONAL_INDENT_OPTIONS>
-    <ADDITIONAL_INDENT_OPTIONS fileType="scala">
-        <option name="INDENT_SIZE" value="2"/>
-        <option name="TAB_SIZE" value="2"/>
-    </ADDITIONAL_INDENT_OPTIONS>
-    <codeStyleSettings language="CFML">
-        <option name="KEEP_LINE_BREAKS" value="false"/>
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-        <option name="BRACE_STYLE" value="2"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
-        <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_IF_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="TERNARY_OPERATION_WRAP" value="5"/>
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-        <option name="FOR_STATEMENT_WRAP" value="1"/>
-        <option name="ASSIGNMENT_WRAP" value="1"/>
-        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
-    </codeStyleSettings>
-    <codeStyleSettings language="ECMA Script Level 4">
-        <option name="KEEP_LINE_BREAKS" value="false"/>
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-        <option name="BLANK_LINES_AFTER_PACKAGE" value="1"/>
-        <option name="BRACE_STYLE" value="2"/>
-        <option name="CLASS_BRACE_STYLE" value="2"/>
-        <option name="METHOD_BRACE_STYLE" value="2"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
-        <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
-        <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_IF_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="EXTENDS_LIST_WRAP" value="1"/>
-        <option name="EXTENDS_KEYWORD_WRAP" value="2"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="TERNARY_OPERATION_WRAP" value="5"/>
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-        <option name="FOR_STATEMENT_WRAP" value="1"/>
-        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-        <option name="ASSIGNMENT_WRAP" value="1"/>
-        <option name="IF_BRACE_FORCE" value="3"/>
-        <option name="DOWHILE_BRACE_FORCE" value="3"/>
-        <option name="WHILE_BRACE_FORCE" value="3"/>
-        <option name="FOR_BRACE_FORCE" value="3"/>
-        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
-    </codeStyleSettings>
-    <codeStyleSettings language="GSP">
-        <indentOptions>
-            <option name="INDENT_SIZE" value="2"/>
-        </indentOptions>
-    </codeStyleSettings>
-    <codeStyleSettings language="Groovy">
-        <option name="KEEP_LINE_BREAKS" value="false"/>
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-        <option name="BLANK_LINES_AROUND_FIELD" value="1"/>
-        <option name="BRACE_STYLE" value="2"/>
-        <option name="CLASS_BRACE_STYLE" value="2"/>
-        <option name="METHOD_BRACE_STYLE" value="2"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
-        <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
-        <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-        <option name="SPACE_WITHIN_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_IF_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="EXTENDS_LIST_WRAP" value="1"/>
-        <option name="THROWS_LIST_WRAP" value="1"/>
-        <option name="EXTENDS_KEYWORD_WRAP" value="2"/>
-        <option name="THROWS_KEYWORD_WRAP" value="2"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="TERNARY_OPERATION_WRAP" value="5"/>
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-        <option name="FOR_STATEMENT_WRAP" value="1"/>
-        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-        <option name="ASSIGNMENT_WRAP" value="1"/>
-        <option name="IF_BRACE_FORCE" value="3"/>
-        <option name="DOWHILE_BRACE_FORCE" value="3"/>
-        <option name="WHILE_BRACE_FORCE" value="3"/>
-        <option name="FOR_BRACE_FORCE" value="3"/>
-        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
-    </codeStyleSettings>
-    <codeStyleSettings language="JAVA">
-        <option name="KEEP_LINE_BREAKS" value="false"/>
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-        <option name="BLANK_LINES_AROUND_FIELD" value="1"/>
-        <option name="BRACE_STYLE" value="2"/>
-        <option name="CLASS_BRACE_STYLE" value="2"/>
-        <option name="METHOD_BRACE_STYLE" value="2"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
-        <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
-        <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true"/>
-        <option name="SPACE_WITHIN_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_IF_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="EXTENDS_LIST_WRAP" value="1"/>
-        <option name="THROWS_LIST_WRAP" value="1"/>
-        <option name="EXTENDS_KEYWORD_WRAP" value="2"/>
-        <option name="THROWS_KEYWORD_WRAP" value="2"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="TERNARY_OPERATION_WRAP" value="5"/>
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-        <option name="FOR_STATEMENT_WRAP" value="1"/>
-        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-        <option name="ASSIGNMENT_WRAP" value="1"/>
-        <option name="IF_BRACE_FORCE" value="3"/>
-        <option name="DOWHILE_BRACE_FORCE" value="3"/>
-        <option name="WHILE_BRACE_FORCE" value="3"/>
-        <option name="FOR_BRACE_FORCE" value="3"/>
-        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
-        <indentOptions>
-            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-        </indentOptions>
-    </codeStyleSettings>
-    <codeStyleSettings language="JSP">
-        <indentOptions>
-            <option name="INDENT_SIZE" value="2"/>
-            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-            <option name="TAB_SIZE" value="2"/>
-        </indentOptions>
-    </codeStyleSettings>
-    <codeStyleSettings language="JavaScript">
-        <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
-        <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="TERNARY_OPERATION_WRAP" value="5"/>
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-        <option name="FOR_STATEMENT_WRAP" value="1"/>
-        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-        <option name="ASSIGNMENT_WRAP" value="1"/>
-        <option name="IF_BRACE_FORCE" value="3"/>
-        <option name="DOWHILE_BRACE_FORCE" value="3"/>
-        <option name="WHILE_BRACE_FORCE" value="3"/>
-        <option name="FOR_BRACE_FORCE" value="3"/>
-        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
-        <indentOptions>
-            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-        </indentOptions>
-    </codeStyleSettings>
-    <codeStyleSettings language="PHP">
-        <option name="KEEP_LINE_BREAKS" value="false"/>
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-        <option name="BLANK_LINES_AROUND_FIELD" value="1"/>
-        <option name="BRACE_STYLE" value="2"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
-        <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
-        <option name="SPACE_WITHIN_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_IF_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true"/>
-        <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="EXTENDS_LIST_WRAP" value="1"/>
-        <option name="THROWS_LIST_WRAP" value="1"/>
-        <option name="EXTENDS_KEYWORD_WRAP" value="2"/>
-        <option name="THROWS_KEYWORD_WRAP" value="2"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="TERNARY_OPERATION_WRAP" value="5"/>
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
-        <option name="FOR_STATEMENT_WRAP" value="1"/>
-        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-        <option name="ASSIGNMENT_WRAP" value="1"/>
-        <option name="IF_BRACE_FORCE" value="3"/>
-        <option name="DOWHILE_BRACE_FORCE" value="3"/>
-        <option name="WHILE_BRACE_FORCE" value="3"/>
-        <option name="FOR_BRACE_FORCE" value="3"/>
-        <option name="ENUM_CONSTANTS_WRAP" value="2"/>
-    </codeStyleSettings>
-    <codeStyleSettings language="SQL">
-        <indentOptions>
-            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-            <option name="TAB_SIZE" value="2"/>
-        </indentOptions>
-    </codeStyleSettings>
-    <codeStyleSettings language="XML">
-        <indentOptions>
-            <option name="INDENT_SIZE" value="2"/>
-            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-            <option name="TAB_SIZE" value="2"/>
-        </indentOptions>
-    </codeStyleSettings>
+  <option name="GENERATE_FINAL_LOCALS" value="true" />
+  <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+    <value>
+      <package name="org.junit.Assert" withSubpackages="true" static="false" />
+    </value>
+  </option>
+  <option name="IMPORT_LAYOUT_TABLE">
+    <value>
+      <package name="java" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javax" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="org" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com.enonic" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com.enonic.cms.framework" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com.enonic.cms" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com.enonic.cms.business" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com.enonic.cms.domain" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="" withSubpackages="true" static="true" />
+    </value>
+  </option>
+  <option name="RIGHT_MARGIN" value="140" />
+  <option name="KEEP_LINE_BREAKS" value="false" />
+  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+  <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+  <option name="BRACE_STYLE" value="2" />
+  <option name="CLASS_BRACE_STYLE" value="2" />
+  <option name="METHOD_BRACE_STYLE" value="2" />
+  <option name="ELSE_ON_NEW_LINE" value="true" />
+  <option name="WHILE_ON_NEW_LINE" value="true" />
+  <option name="CATCH_ON_NEW_LINE" value="true" />
+  <option name="FINALLY_ON_NEW_LINE" value="true" />
+  <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+  <option name="SPACE_WITHIN_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+  <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true" />
+  <option name="CALL_PARAMETERS_WRAP" value="1" />
+  <option name="METHOD_PARAMETERS_WRAP" value="1" />
+  <option name="EXTENDS_LIST_WRAP" value="1" />
+  <option name="THROWS_LIST_WRAP" value="1" />
+  <option name="EXTENDS_KEYWORD_WRAP" value="2" />
+  <option name="THROWS_KEYWORD_WRAP" value="2" />
+  <option name="BINARY_OPERATION_WRAP" value="1" />
+  <option name="TERNARY_OPERATION_WRAP" value="5" />
+  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+  <option name="FOR_STATEMENT_WRAP" value="1" />
+  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+  <option name="ASSIGNMENT_WRAP" value="1" />
+  <option name="IF_BRACE_FORCE" value="3" />
+  <option name="DOWHILE_BRACE_FORCE" value="3" />
+  <option name="WHILE_BRACE_FORCE" value="3" />
+  <option name="FOR_BRACE_FORCE" value="3" />
+  <option name="ENUM_CONSTANTS_WRAP" value="2" />
+  <JSCodeStyleSettings>
+    <option name="SPACE_AFTER_PROPERTY_COLON" value="true" />
+  </JSCodeStyleSettings>
+  <XML>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <ADDITIONAL_INDENT_OPTIONS fileType="haml">
+    <option name="INDENT_SIZE" value="2" />
+  </ADDITIONAL_INDENT_OPTIONS>
+  <ADDITIONAL_INDENT_OPTIONS fileType="scala">
+    <option name="INDENT_SIZE" value="2" />
+    <option name="TAB_SIZE" value="2" />
+  </ADDITIONAL_INDENT_OPTIONS>
+  <codeStyleSettings language="CFML">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+  </codeStyleSettings>
+  <codeStyleSettings language="ECMA Script Level 4">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BLANK_LINES_AFTER_PACKAGE" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="2" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+  </codeStyleSettings>
+  <codeStyleSettings language="GSP">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="Groovy">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="SPACE_WITHIN_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="2" />
+    <option name="THROWS_KEYWORD_WRAP" value="2" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+  </codeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+    <option name="SPACE_WITHIN_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="2" />
+    <option name="THROWS_KEYWORD_WRAP" value="2" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JSP">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JavaScript">
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="INDENT_CASE_FROM_SWITCH" value="false" />
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+  </codeStyleSettings>
+  <codeStyleSettings language="PHP">
+    <option name="KEEP_LINE_BREAKS" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+    <option name="BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="WHILE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="SPACE_WITHIN_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_CALL_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_METHOD_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_FOR_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+    <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="2" />
+    <option name="THROWS_KEYWORD_WRAP" value="2" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_WRAP" value="5" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="ENUM_CONSTANTS_WRAP" value="2" />
+  </codeStyleSettings>
+  <codeStyleSettings language="SQL">
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
 </code_scheme>
 

--- a/javascript/code-quality-tools/js-lint-configurations/idea/jslint.xml
+++ b/javascript/code-quality-tools/js-lint-configurations/idea/jslint.xml
@@ -2,10 +2,13 @@
 <project version="4">
   <component name="JSLintConfiguration">
     <option browser="true" />
+    <option devel="true" />
     <option indent="4" />
     <option maxerr="50" />
-    <option predef="Ext, Admin, AdminLiveEdit, $liveedit" />
+    <option plusplus="true" />
+    <option predef="Ext, Admin, AdminLiveEdit, $liveedit, Templates" />
     <option sloppy="true" />
     <option vars="true" />
   </component>
 </project>
+


### PR DESCRIPTION
From sprint 90 we want to start using JSLint as a standard for the JS Code -> http://www.jslint.com/

The JS code style in the project has now been optimized for JSLint

Task:
1. Make sure you have the latest codestyle and jslint setup for your project (https://github.com/enonic/dev-tools)
2. Go through each file in the Project and apply the code style and fix any errors found by JSLint

(also make sure duplicate variables warnings are fixed)